### PR TITLE
adding ID attribute to microarticle node

### DIFF
--- a/src/BorgerDk/ArticleService/Resources/ArticleAbstract.php
+++ b/src/BorgerDk/ArticleService/Resources/ArticleAbstract.php
@@ -77,6 +77,7 @@ abstract class ArticleAbstract extends ResourceAbstract
         $data->microArticles = $crawler->filter('#kernetekst > div')->each(
             function (Crawler $node, $i) {
                 $link = new \stdClass();
+                $link->id = $this->getAttributeId($node);
                 $link->headline = trim($node->filter('h2')->text());
                 $link->content = trim($node->filter('div > div')->html());
                 return $link;


### PR DESCRIPTION
following the logic of creation self-service link,
any specific reason why ID was not included?