### PR TITLE
changing visibility of formatSingleArticle

### DIFF
--- a/src/BorgerDk/ArticleService/Resources/ArticleAbstract.php
+++ b/src/BorgerDk/ArticleService/Resources/ArticleAbstract.php
@@ -47,7 +47,7 @@ abstract class ArticleAbstract extends ResourceAbstract
      *
      * @return \stdClass
      */
-    private function formatSingleArticle($article)
+    public function formatSingleArticle($article)
     {
         $data = new \stdClass();
         $html = utf8_decode($article->Content);


### PR DESCRIPTION
some of the articles (e.g. ID: 354) cause fatal error during formatting, which makes the whole batch of articles fail the formatting.

opening the method for single article formatting will allow developers to catch individual article formatting errors.