### PR TITLE
Updated symfony/dom-crawler and symfony/css-selector version constrains 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/dom-crawler": "2.8.*|3.2.*",
-        "symfony/css-selector": "2.8.*|3.2.*"
+        "symfony/dom-crawler": "2.8.*|3.4.*",
+        "symfony/css-selector": "2.8.*|3.4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*"


### PR DESCRIPTION
This merge request updates the version constraints for symfony/dom-crawler and symfony/css-selecto to avoid conflicts with Drupal >=8.4.x 

#10 