### PR TITLE
Upgrade dependency versions + fix unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ vendor
 
 // OSX
 .DS_Store
+
+// Phpunit
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: php
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 5.5
   - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
 
 before_install:
   - phpenv config-rm xdebug.ini

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://poser.pugx.org/ffwagency/borgerdk-php/license)](https://packagist.org/packages/ffwagency/borgerdk-php)
 
 ## Requirements
-* PHP 5.4+
+* PHP 7.1+
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,11 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/dom-crawler": "2.8.*|3.4.*",
-        "symfony/css-selector": "2.8.*|3.4.*"
+        "symfony/dom-crawler": "2.8.* || 3.4.* || 4.4.*",
+        "symfony/css-selector": "2.8.* || 3.4.* || 4.4.*"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.8.*"
+        "phpunit/phpunit": "~6.5 || ~7 || ~8.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
+        "php": ">=7.1.0",
         "symfony/dom-crawler": "2.8.* || 3.4.* || 4.4.*",
         "symfony/css-selector": "2.8.* || 3.4.* || 4.4.*"
     },

--- a/tests/BorgerDk/ArticleService/UnitTests/BasicTest.php
+++ b/tests/BorgerDk/ArticleService/UnitTests/BasicTest.php
@@ -11,7 +11,7 @@
 
 namespace BorgerDk\ArticleService\UnitTests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase as UnitTestCase;
 use BorgerDk\ArticleService;
 use BorgerDk\ArticleService\Client as Client;
 
@@ -20,7 +20,7 @@ use BorgerDk\ArticleService\Client as Client;
  *
  * @package BorgerDk\ArticleService
  */
-abstract class BasicTest extends \PHPUnit_Framework_TestCase
+abstract class BasicTest extends UnitTestCase
 {
     /**
      * Client Connection
@@ -83,8 +83,9 @@ abstract class BasicTest extends \PHPUnit_Framework_TestCase
     /**
      * Initiate the new Soap Client in the setup method.
      */
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->client = new Client();
     }
 }

--- a/tests/BorgerDk/ArticleService/UnitTests/Resources/Endpoints/GetAllArticlesTest.php
+++ b/tests/BorgerDk/ArticleService/UnitTests/Resources/Endpoints/GetAllArticlesTest.php
@@ -29,7 +29,7 @@ class GetAllArticlesTest extends BasicTest
     /**
      * Setup the endpoint request.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->endpoint = new GetAllArticles($this->client);

--- a/tests/BorgerDk/ArticleService/UnitTests/Resources/Endpoints/GetAllSitesTest.php
+++ b/tests/BorgerDk/ArticleService/UnitTests/Resources/Endpoints/GetAllSitesTest.php
@@ -19,7 +19,7 @@ use BorgerDk\ArticleService\Resources\Endpoints\GetAllSites;
  *
  * @package BorgerDk\ArticleService
  */
-class GetAllSitesTEst extends BasicTest
+class GetAllSitesTest extends BasicTest
 {
     /**
      * @var object
@@ -29,7 +29,7 @@ class GetAllSitesTEst extends BasicTest
     /**
      * Setup the endpoint request.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->endpoint = new GetAllSites($this->client);

--- a/tests/BorgerDk/ArticleService/UnitTests/Resources/Endpoints/GetArticleByIDTest.php
+++ b/tests/BorgerDk/ArticleService/UnitTests/Resources/Endpoints/GetArticleByIDTest.php
@@ -29,7 +29,7 @@ class GetArticleByIDTest extends BasicTest
     /**
      * Setup the endpoint request.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $params = array('articleID' => $this->articleId1, 'municipalityCode' => $this->municipalityCode);

--- a/tests/BorgerDk/ArticleService/UnitTests/Resources/Endpoints/GetArticleIDByUrlTest.php
+++ b/tests/BorgerDk/ArticleService/UnitTests/Resources/Endpoints/GetArticleIDByUrlTest.php
@@ -29,7 +29,7 @@ class GetArticleIDByUrlTest extends BasicTest
     /**
      * Setup the endpoint request.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $params = array('url' => $this->articleUrl);

--- a/tests/BorgerDk/ArticleService/UnitTests/Resources/Endpoints/GetArticleIDsBySiteIDTest.php
+++ b/tests/BorgerDk/ArticleService/UnitTests/Resources/Endpoints/GetArticleIDsBySiteIDTest.php
@@ -29,7 +29,7 @@ class GetArticleIDsBySiteIDTest extends BasicTest
     /**
      * Setup the endpoint request.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $params = array('siteID' => $this->siteId);

--- a/tests/BorgerDk/ArticleService/UnitTests/Resources/Endpoints/GetArticlesByIDsTest.php
+++ b/tests/BorgerDk/ArticleService/UnitTests/Resources/Endpoints/GetArticlesByIDsTest.php
@@ -29,7 +29,7 @@ class GetArticlesByIDsTest extends BasicTest
     /**
      * Setup the endpoint request.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $articleIds = array($this->articleId1, $this->articleId2);

--- a/tests/BorgerDk/ArticleService/UnitTests/Resources/Endpoints/GetMunicipalityListTest.php
+++ b/tests/BorgerDk/ArticleService/UnitTests/Resources/Endpoints/GetMunicipalityListTest.php
@@ -29,7 +29,7 @@ class GetMunicipalityListTest extends BasicTest
     /**
      * Setup the endpoint request.
      */
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->endpoint = new GetMunicipalityList($this->client);


### PR DESCRIPTION
- Add support for CSS Crawler 4.4 
- Add support DOM Crawler 4.4
- Upgrade to newer PHP Unit versions used by Drupal 8.8 and Drupal 9.0
- Fix test cases to be compatible with the new PHP Unit versions.
- PHP minimum support is changed to 7.1